### PR TITLE
Fixed OOPS! RESTFUL Web Service request

### DIFF
--- a/src/main/java/oops/OOPSevaluation.java
+++ b/src/main/java/oops/OOPSevaluation.java
@@ -60,7 +60,7 @@ public class OOPSevaluation {
                 }
                 request+="</OntologyUrl><OntologyContent>";
                 if(content!=null &&!"".equals(content)){
-                    request+=content;
+                    request+="<![CDATA[ "+content+" ]]>";
                 }
                 request+="</OntologyContent>"+
                     "<Pitfalls></Pitfalls>" +

--- a/src/main/java/widoco/CreateOOPSEvalInThread.java
+++ b/src/main/java/widoco/CreateOOPSEvalInThread.java
@@ -48,9 +48,15 @@ public class CreateOOPSEvalInThread implements Runnable{
             String evaluation;
             OOPSevaluation eval;
             
+            String ontologyXMLPath = c.getDocumentationURI();                          
+            if(!c.getMainOntology().isHashOntology()){
+                ontologyXMLPath+=File.separator+"doc";
+            }
+            ontologyXMLPath +=File.separator+"ontology.xml";
+            
             //read file
             String content=null;
-            BufferedReader br = new BufferedReader(new FileReader(c.getOntologyPath()));
+            BufferedReader br = new BufferedReader(new FileReader(ontologyXMLPath));
             try {
                 StringBuilder sb = new StringBuilder();
                 String line = br.readLine();


### PR DESCRIPTION
OOPS! RESTFUL Web Service only responds correctly to rdf data in the xml format. 
The [specifications ](http://oops-ws.oeg-upm.net/) also states the following:

> OntologyContent: ontology RDF source code. Highly important: the RDF code must be contained inside `<![CDATA[ RDF code ]]>`. Otherwise, the code won’t be read properly. Mandatory if OntologyUrl field is empty.

which was not correctly implemented.
Fixed both issues.