### PR TITLE
Fix Abstract Section and bibo:status

### DIFF
--- a/src/main/java/widoco/Configuration.java
+++ b/src/main/java/widoco/Configuration.java
@@ -540,12 +540,7 @@ public class Configuration {
                 break;
             case Constants.PROP_BIBO_STATUS:
                 try{
-                    valueLanguage = a.getValue().asLiteral().get().getLang();
                     value = a.getValue().asLiteral().get().getLiteral();
-                    if(this.currentLanguage.equals(valueLanguage)||
-                            (abstractSection==null || "".equals(abstractSection))){
-                        abstractSection = value;
-                    }
                     mainOntologyMetadata.setStatus(value);
                 }catch(Exception e){
                     System.err.println("Error while getting the status. No literal provided");


### PR DESCRIPTION
The deleted lines falsely set the content of the abstract section to the bibo:status and prevents the if-statement on the lines 451-454 from setting it to the proper content. 