### PR TITLE
Improved error handling

### DIFF
--- a/src/main/java/widoco/Configuration.java
+++ b/src/main/java/widoco/Configuration.java
@@ -147,7 +147,7 @@ public class Configuration {
 			String path = (new File(root.toURI())).getParentFile().getPath();
 			loadPropertyFile(path + File.separator + Constants.CONFIG_PATH);
 		} catch (URISyntaxException | IOException e) {
-			logger.error("Error while loading the default property file: " + e.getMessage());
+			logger.warn("Error while loading the default property file: " + e.getMessage());
 		}
 	}
 
@@ -366,7 +366,8 @@ public class Configuration {
 			this.googleAnalyticsCode = propertyFile.getProperty("GoogleAnalyticsCode");
 
 		} catch (IOException ex) {
-			logger.error("Error while reading configuration properties " + ex.getMessage());
+			// Only a warning, as we can continue safely without a property file.
+			logger.warn("Error while reading configuration properties from [" + path + "]: " + ex.getMessage());
 			throw ex;
 		}
 		// } catch (Exception ex) {
@@ -673,7 +674,8 @@ public class Configuration {
 		try {
 			this.loadPropertyFile(path);
 		} catch (IOException ex) {
-			logger.error("Error while reading configuration properties " + ex.getMessage());
+			// Only a warning, as we can continue safely without a property file.
+			logger.warn("Error while reading configuration properties from [" + path + "]: " + ex.getMessage());
 		}
 	}
 
@@ -688,6 +690,10 @@ public class Configuration {
 
 	public Ontology getMainOntology() {
 		return mainOntologyMetadata;
+	}
+
+	public String getInputOntology() {
+		return ((this.isFromFile() ? "File: " : "URI: ") + getOntologyPath());
 	}
 
 	public String getOntologyPath() {

--- a/src/main/java/widoco/WidocoUtils.java
+++ b/src/main/java/widoco/WidocoUtils.java
@@ -122,7 +122,9 @@ public class WidocoUtils {
 				break; // if the vocabulary is downloaded, then we don't download it for the other
 						// serializations
 			} catch (Exception e) {
-				logger.error("Failed to download vocabulary in " + serialization);
+				final String message = "Failed to download vocabulary in RDF format [" + serialization +"]: ";
+				logger.error(message + e.toString());
+				throw new RuntimeException(message, e);
 			}
 		}
 	}


### PR DESCRIPTION
Issue #245 doesn't provide much detail (and error handling in general could use some major attention), but this PR at least reports (even if no log4j.properties file is found) when the input ontology is not found. It also exits with a proper error code on failure (i.e. '1' instead of '0'), and logs warnings instead of errors if optional property files not found on startup.