### PR TITLE
Only show legend entries if relevant

### DIFF
--- a/src/main/java/widoco/Constants.java
+++ b/src/main/java/widoco/Constants.java
@@ -1265,18 +1265,48 @@ public class Constants {
 		return page406;
 	}
 
-	public static String getLegend(Properties lang) {
+	public static String getLegend(
+			Properties lang,
+			final boolean includesClass,
+			final boolean includesProperty,
+			final boolean includesDatatypeProperty,
+			final boolean includesAnnotation,
+			final boolean includesNamedIndividual) {
+
+		// If our ontology is empty, then no point in a legend at all!
+		if (!includesClass && !includesProperty && !includesDatatypeProperty &&
+				!includesAnnotation && !includesNamedIndividual) {
+			return "";
+		}
+
+		// TODO: Currently legend has no entry for Annotations - I don't know if this is intended or
+		//  not ...?
 		return "<div id=\"legend\">\n" + "<h2>" + lang.getProperty(Constants.LANG_LEGEND)
 				+ " <span class=\"backlink\"> " + lang.getProperty(Constants.LANG_BACK)
-				+ " <a href=\"#toc\">ToC</a></span></h2>\n" + "<div   class=\"entity\">\n"
-				+ "<sup class=\"type-c\" title=\"" + lang.getProperty(Constants.LANG_CLASSES) + "\">c</sup>: "
-				+ lang.getProperty(Constants.LANG_CLASSES) + " <br/>\n" + "<sup class=\"type-op\" title=\""
-				+ lang.getProperty(Constants.LANG_OBJ_PROP) + "\">op</sup>: "
-				+ lang.getProperty(Constants.LANG_OBJ_PROP) + " <br/>\n" + "<sup class=\"type-dp\" title=\""
-				+ lang.getProperty(Constants.LANG_DATA_PROP) + "\">dp</sup>: "
-				+ lang.getProperty(Constants.LANG_DATA_PROP) + " <br/>\n" + "<sup class=\"type-ni\" title=\""
-				+ lang.getProperty(Constants.LANG_NAMED_INDIV) + "\">ni</sup>: "
-				+ lang.getProperty(Constants.LANG_NAMED_INDIV) + "\n" + "</div>\n" + "</div>";
+				+ " <a href=\"#toc\">ToC</a></span></h2>\n"
+				+ "<div   class=\"entity\">\n"
+				+ (includesClass ?
+				  "<sup class=\"type-c\" title=\""
+				  + lang.getProperty(Constants.LANG_CLASSES)
+				  + "\">c</sup>: " + lang.getProperty(Constants.LANG_CLASSES) + " <br/>\n"
+				  : "")
+				+ (includesProperty ?
+				  "<sup class=\"type-op\" title=\""
+				  + lang.getProperty(Constants.LANG_OBJ_PROP) + "\">op</sup>: "
+				  + lang.getProperty(Constants.LANG_OBJ_PROP) + " <br/>\n"
+				  : "")
+				+ (includesDatatypeProperty ?
+				  "<sup class=\"type-dp\" title=\""
+				  + lang.getProperty(Constants.LANG_DATA_PROP) + "\">dp</sup>: "
+				  + lang.getProperty(Constants.LANG_DATA_PROP) + " <br/>\n"
+				  : "")
+				+ (includesNamedIndividual ?
+				  "<sup class=\"type-ni\" title=\""
+				  + lang.getProperty(Constants.LANG_NAMED_INDIV) + "\">ni</sup>: "
+				  + lang.getProperty(Constants.LANG_NAMED_INDIV) + "\n"
+				: "")
+				+ "</div>\n" + "</div>"
+				+ "\n";
 	}
 
 	public static String getAnalyticsCode(String code) {

--- a/src/main/java/widoco/CreateResources.java
+++ b/src/main/java/widoco/CreateResources.java
@@ -306,28 +306,40 @@ public class CreateResources {
 
 	private static String createCrossReferenceSection(String path, LODEParser lodeParser, Configuration c,
 			Properties lang) {
-            // cross reference section has to be included always.
+            // Cross reference section has to be included always.
             String textToWrite = Constants.getCrossReferenceSectionTitleAndPlaceHolder(c, lang);
+
             String classesList = lodeParser.getClassList(), propList = lodeParser.getPropertyList(),
                             dataPropList = lodeParser.getDataPropList(), annotationPropList = lodeParser.getAnnotationPropList(),
                             namedIndividualList = lodeParser.getNamedIndividualList();
-            if (classesList != null && !"".equals(classesList)) {
-                    textToWrite += lodeParser.getClasses();
+
+			final boolean includesClass = classesList != null && !"".equals(classesList);
+			final boolean includesProperty = propList != null && !"".equals(propList);
+			final boolean includesDatatypeProperty = dataPropList != null && !"".equals(dataPropList);
+			final boolean includesAnnotation =
+				c.isIncludeAnnotationProperties() && annotationPropList != null && !"".equals(annotationPropList);
+			final boolean includesNamedIndividual =
+				c.isIncludeNamedIndividuals() && namedIndividualList != null && !"".equals(namedIndividualList);
+
+			if (includesClass) {
+				textToWrite += lodeParser.getClasses();
             }
-            if (propList != null && !"".equals(propList)) {
-                    textToWrite += lodeParser.getProperties();
+            if (includesProperty) {
+				textToWrite += lodeParser.getProperties();
             }
-            if (dataPropList != null && !"".equals(dataPropList)) {
-                    textToWrite += lodeParser.getDataProp();
+            if (includesDatatypeProperty) {
+				textToWrite += lodeParser.getDataProp();
             }
-            if (c.isIncludeAnnotationProperties() && annotationPropList != null && !"".equals(annotationPropList)) {
-                    textToWrite += lodeParser.getAnnotationProp();
+            if (includesAnnotation) {
+				textToWrite += lodeParser.getAnnotationProp();
             }
-            if (c.isIncludeNamedIndividuals() && namedIndividualList != null && !"".equals(namedIndividualList)) {
-                    textToWrite += lodeParser.getNamedIndividuals();
+            if (includesNamedIndividual) {
+				textToWrite += lodeParser.getNamedIndividuals();
             }
-            // add legend
-            textToWrite += Constants.getLegend(lang) + "\n";
+
+            // Add legend (for ontology components actually used).
+            textToWrite += Constants.getLegend(lang, includesClass, includesProperty,
+					includesDatatypeProperty, includesAnnotation, includesNamedIndividual);
             if(!c.isIncludeAllSectionsInOneDocument()){
                 saveDocument(path + File.separator + "crossref-" + c.getCurrentLanguage() + ".html", textToWrite, c);
             }


### PR DESCRIPTION
The legend shown in the HTML might be a little confusing for people looking at very simple vocabularies, i.e., vocabs that have any NamedIndividual, or DatatypeProperties. So this PR changes the legend-generation code to only display legend entries if the vocabulary does in fact contain at least one term of that legend-entry type.