### PR TITLE
switch import fonts to always use https scheme

### DIFF
--- a/src/main/resources/lode/bootstrap-yeti-old.css
+++ b/src/main/resources/lode/bootstrap-yeti-old.css
@@ -1,5 +1,5 @@
-@import url("//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700,800");
-@import url("//fonts.googleapis.com/css?family=Montserrat:400,700");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700,800");
+@import url("https://fonts.googleapis.com/css?family=Montserrat:400,700");
 
 /*!
  * Bootswatch v3.1.0+1

--- a/src/main/resources/lode/bootstrap-yeti.css
+++ b/src/main/resources/lode/bootstrap-yeti.css
@@ -1,5 +1,5 @@
-@import url("//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700,800");
-@import url("//fonts.googleapis.com/css?family=Montserrat:400,700");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700,800");
+@import url("https://fonts.googleapis.com/css?family=Montserrat:400,700");
 
 /*!
  * Bootswatch v3.1.0+1


### PR DESCRIPTION
both current firefox and chromium  interpret "//fonts...." as "http://" resulting
in them blocking the import due to mixed-content policy when the index
is served from a https page.

AFAIK the reverse should always be fine, a resource with "https" from
within a "http" page.