### PR TITLE
Replace license URL placeholders with example.org subdomains.

### DIFF
--- a/src/main/java/widoco/Constants.java
+++ b/src/main/java/widoco/Constants.java
@@ -904,7 +904,7 @@ public class Constants {
 
 		if (c.getMainOntology().getLicense() != null) {
 			String lname = c.getMainOntology().getLicense().getName();// "license name goes here";
-			String licenseURL = c.getMainOntology().getLicense().getUrl();// "http://insertlicenseURIhere.org";
+			String licenseURL = c.getMainOntology().getLicense().getUrl();// "http://insertlicenseURIhere.example.org";
 			if (licenseURL == null || "".equals(licenseURL))
 				licenseURL = l.getProperty(LANG_LICENSE_URL_IF_NULL);
 			if (lname == null || "".equals(lname))

--- a/src/main/resources/widoco/cs.properties
+++ b/src/main/resources/widoco/cs.properties
@@ -13,7 +13,7 @@ abstract=Abstrakt
 abstractPlaceHolder=Toto je m\u00edsto, na kter\u00e9 pat\u0159\u00ed abstrakt. Abstrakt by m\u011bl obsahovat n\u011bkolik v\u011bt shrnuj\u00edc\u00edch obsah ontologie a jej\u00ed \u00fa\u010del.
 license=Licence: 
 licenseIfNull=Zde dopl\u0148te n\u00e1zev licence
-licenseURLIfNull=http://vlozUriLicenceZde.org
+licenseURLIfNull=http://vlozUriLicenceZde.example.org
 toc=Obsah
 ns=Deklarace jmenn\u00fdch prostor\u016f
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Table 1</a>: Jmenn\u00e9 prostory pou\u017eit\u00e9 v tomto dokumentut </caption>\n<tbody>\n

--- a/src/main/resources/widoco/de.properties
+++ b/src/main/resources/widoco/de.properties
@@ -13,7 +13,7 @@ abstract=Zusammenfassung
 abstractPlaceHolder=Dies ist ein Platzhalter f&uuml;r die Zusammenfassung. Die Zusammenfassung sollte einige S&auml;tze enthalten, die die Ontologie und ihren Anwendungszweck beschreibt.
 license=Lizenz:
 licenseIfNull=Dies ist der Lizenzname
-licenseURLIfNull=http://insertlicenseURIhere.org
+licenseURLIfNull=http://insertlicenseURIhere.example.org
 toc=Inhaltsverzeichnis
 ns=Namensr&auml;ume
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Tabelle 1</a>: Namensr&auml;ume im Dokument </caption>\n<tbody>\n

--- a/src/main/resources/widoco/en.properties
+++ b/src/main/resources/widoco/en.properties
@@ -13,7 +13,7 @@ abstract=Abstract
 abstractPlaceHolder=This is a placeholder text for the abstract. The abstract should contain a couple of sentences summarizing the ontology and its purpose.
 license=License:
 licenseIfNull=license name goes here
-licenseURLIfNull=http://insertlicenseURIhere.org
+licenseURLIfNull=http://insertlicenseURIhere.example.org
 toc=Table of contents
 ns=Namespace declarations
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Table 1</a>: Namespaces used in the document </caption>\n<tbody>\n

--- a/src/main/resources/widoco/es.properties
+++ b/src/main/resources/widoco/es.properties
@@ -13,7 +13,7 @@ abstract=S&iacute;ntesis
 abstractPlaceHolder=Este es el lugar donde escribir un resumen de la ontolog&iacute;a. Un par de frases bastan para resumir su prop&oacute;sito.
 license=Licencia:
 licenseIfNull=Insertar el t&iacute;tulo de la licencia aqu&iacute
-licenseURLIfNull=http://tituloLicenciaSeleccionado.org
+licenseURLIfNull=http://tituloLicenciaSeleccionado.example.org
 toc=&Iacute;ndice
 ns=Declaraci&oacute;n de namespaces
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Tabla 1</a>: Namespaces utilizados en el documento </caption>\n<tbody>\n

--- a/src/main/resources/widoco/fr.properties
+++ b/src/main/resources/widoco/fr.properties
@@ -13,7 +13,7 @@ abstract=R&eacute;sum&eacute;
 abstractPlaceHolder=Ceci est un r&eacute;sum&eacute; automatique . Le r&eacute;sum&eacute; doit contenir quelques phrases qui r&eacute;sument l'ontologie et son utilit&eacute;.
 license=Licence: 
 licenseIfNull=nom de la licence
-licenseURLIfNull=http://URIdelalicence.org
+licenseURLIfNull=http://URIdelalicence.example.org
 toc=Sommaire
 ns=Espaces de noms d&eacute;clar&eacute;s
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Table 1</a>: Espaces de noms utilis&eacute;s dans ce document </caption>\n<tbody>\n

--- a/src/main/resources/widoco/it.properties
+++ b/src/main/resources/widoco/it.properties
@@ -18,7 +18,7 @@ abstract=Abstract
 abstractPlaceHolder=Qui va inserito il testo dell'abstract. L'abstract dovrebbe contenere una descrizione sintetica dell'ontologia e degli scopi a cui &egrave;  destinata.
 license=Licenza: 
 licenseIfNull=Qui va il nome della licenza
-licenseURLIfNull=http://insertlicenseURIhere.org
+licenseURLIfNull=http://insertlicenseURIhere.example.org
 toc=Table of contents
 ns=Lista dei namespace
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Tabella 1</a>: Lista dei namespace usati nel documento </caption>\n<tbody>\n

--- a/src/main/resources/widoco/nl.properties
+++ b/src/main/resources/widoco/nl.properties
@@ -13,7 +13,7 @@ abstract=Samenvatting
 abstractPlaceHolder=Dit is een tijdelijke tekst voor de samenvatting. De samenvatting moet een paar zinnen bevatten die de ontologie en het doel ervan samenvatten.
 license=Licentie: 
 licenseIfNull=Licentienaam staat hier
-licenseURLIfNull=http://voeglicentieURIhiertoe.org
+licenseURLIfNull=http://voeglicentieURIhiertoe.example.org
 toc=Inhoudsopgave
 ns=Naamruimtedefinities
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Table 1</a>: Gebruikte naamruimten in dit document </caption>\n<tbody>\n

--- a/src/main/resources/widoco/pt.properties
+++ b/src/main/resources/widoco/pt.properties
@@ -13,7 +13,7 @@ abstract=Sum&aacute;rio
 abstractPlaceHolder=Aqui vai o resumo. Um par de frases que resumem a ontologia e sua finalidade.
 license=Licen&ccedil;a: 
 licenseIfNull=nome de licen&ccedil;a vai aqui
-licenseURLIfNull=http://insertlicenseURIhere.org
+licenseURLIfNull=http://insertlicenseURIhere.example.org
 toc=&Iacute;ndice
 ns=Declara&ccedil;&otilde;es de namespaces
 nsText=</h3>\n<div id=\"ns\" align=\"center\">\n<table>\n<caption> <a href=\"#ns\"> Table 1</a>: Namespaces utilizados no documento </caption>\n<tbody>\n


### PR DESCRIPTION
I noticed that the (English) license URL placeholder resolves to a suspicious website, so I changed the placeholders to be subdomains of `example.org`, an [IANA-managed reserved domain](https://www.iana.org/domains/reserved).