### PR TITLE
install font-related dependencies in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN mvn package && \
 # ----
 FROM openjdk:17-slim
 
+RUN apt-get update
+RUN apt-get install -y libfreetype6 fontconfig
+
 WORKDIR /usr/local/widoco
 
 COPY --from=BUILD_IMAGE /var/build/widoco/JAR/widoco.jar .


### PR DESCRIPTION
Re-running dockerized widoco on an existing output would fail without these.
Example of failing command (run twice in docker container):
```
sh -c java ${JAVA_OPTS} -jar widoco.jar -ontFile in/example-ontology.ttl -outFolder out
```

Stack-trace of the error that used to be produced:
```
 [main] INFO widoco.gui.GuiController - 
 
 --WIzard for DOCumenting Ontologies (WIDOCO).
  https://w3id.org/widoco/
 
 [main] WARN widoco.Configuration - Error while reading configuration properties from [/usr/local/widoco/config/config.properties]: /usr/local/widoco/config/config.properties (No such file or directory)
 [main] WARN widoco.Configuration - Error while loading the default property file: /usr/local/widoco/config/config.properties (No such file or directory)
 [main] WARN widoco.Configuration - Error while reading configuration properties from []:  (No such file or directory)
 [main] WARN widoco.Configuration - Error while reading configuration properties from []:  (No such file or directory)
 [main] INFO widoco.gui.GuiController - Processed configuration, loading ontology now. isFromFile=true
 [main] INFO widoco.WidocoUtils - Load ontology in/example-ontology.ttl
 [main] INFO widoco.CatalogIRIMapper - Creating JenaCatalogIRIMapper
 [main] WARN org.semanticweb.owlapi.util.SAXParsers - http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit not supported by parser type org.apache.xerces.jaxp.SAXParserImpl, error message: Property 'http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit' is not recognized.
 [main] WARN org.semanticweb.owlapi.util.SAXParsers - entityExpansionLimit not supported by parser type org.apache.xerces.jaxp.SAXParserImpl, error message: Property 'entityExpansionLimit' is not recognized.
 [main] WARN org.semanticweb.owlapi.util.SAXParsers - http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit not supported by parser type org.apache.xerces.jaxp.SAXParserImpl, error message: Property 'http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit' is not recognized.
 [main] WARN org.semanticweb.owlapi.util.SAXParsers - entityExpansionLimit not supported by parser type org.apache.xerces.jaxp.SAXParserImpl, error message: Property 'entityExpansionLimit' is not recognized.
 [main] INFO widoco.gui.GuiController - Generating documentation for in/example-ontology.ttl in lang en
 [main] INFO widoco.gui.GuiController - Load properties from the ontology in lang en
 [main] INFO widoco.CreateResources - Generate documentation in out
 [main] INFO widoco.CreateResources - - ontology IRI: http://data.example.com/
 [main] INFO widoco.LODEParser - Parsing Complete!
 Exception in thread "main" java.lang.UnsatisfiedLinkError: /usr/local/openjdk-17/lib/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
 	at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
 	at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:388)
 	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:232)
 	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:174)
 	at java.base/jdk.internal.loader.NativeLibraries.findFromPaths(NativeLibraries.java:315)
 	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:285)
 	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2398)
 	at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:818)
 	at java.base/java.lang.System.loadLibrary(System.java:1989)
 	at java.desktop/sun.font.FontManagerNativeLibrary$1.run(FontManagerNativeLibrary.java:58)
 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
 	at java.desktop/sun.font.FontManagerNativeLibrary.<clinit>(FontManagerNativeLibrary.java:33)
 	at java.desktop/sun.font.SunFontManager$1.run(SunFontManager.java:275)
 	at java.desktop/sun.font.SunFontManager$1.run(SunFontManager.java:273)
 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
 	at java.desktop/sun.font.SunFontManager.initStatic(SunFontManager.java:273)
 	at java.desktop/sun.font.SunFontManager.<clinit>(SunFontManager.java:268)
 	at java.desktop/sun.font.FontDesignMetrics.getMetrics(FontDesignMetrics.java:266)
 	at java.desktop/sun.swing.SwingUtilities2.getFontMetrics(SwingUtilities2.java:1242)
 	at java.desktop/javax.swing.JComponent.getFontMetrics(JComponent.java:1691)
 	at java.desktop/javax.swing.plaf.basic.BasicGraphicsUtils.getPreferredButtonSize(BasicGraphicsUtils.java:356)
 	at java.desktop/javax.swing.plaf.basic.BasicButtonUI.getPreferredSize(BasicButtonUI.java:523)
 	at java.desktop/javax.swing.plaf.basic.BasicButtonUI.getMinimumSize(BasicButtonUI.java:513)
 	at java.desktop/javax.swing.JComponent.getMinimumSize(JComponent.java:1805)
 	at java.desktop/javax.swing.plaf.basic.BasicOptionPaneUI.addButtonComponents(BasicOptionPaneUI.java:783)
 	at java.desktop/javax.swing.plaf.basic.BasicOptionPaneUI.createButtonArea(BasicOptionPaneUI.java:716)
 	at java.desktop/javax.swing.plaf.basic.BasicOptionPaneUI.installComponents(BasicOptionPaneUI.java:205)
 	at java.desktop/javax.swing.plaf.basic.BasicOptionPaneUI.installUI(BasicOptionPaneUI.java:159)
 	at java.desktop/javax.swing.JComponent.setUI(JComponent.java:730)
 	at java.desktop/javax.swing.JOptionPane.setUI(JOptionPane.java:1857)
 	at java.desktop/javax.swing.JOptionPane.updateUI(JOptionPane.java:1879)
 	at java.desktop/javax.swing.JOptionPane.<init>(JOptionPane.java:1844)
 	at java.desktop/javax.swing.JOptionPane.showOptionDialog(JOptionPane.java:868)
 	at widoco.CreateResources.saveDocument(CreateResources.java:403)
 	at widoco.CreateResources.createAbstractSection(CreateResources.java:227)
 	at widoco.CreateResources.generateDocumentation(CreateResources.java:89)
 	at widoco.gui.GuiController.<init>(GuiController.java:302)
 	at widoco.gui.GuiController.main(GuiController.java:528)
example-ontology_widoco_1 exited with code 1
```