### PR TITLE
Fixed SWRL Toc

### DIFF
--- a/src/main/resources/lode/cs.xml
+++ b/src/main/resources/lode/cs.xml
@@ -70,6 +70,7 @@
     <developedby>vyvinuto</developedby>
     <or>nebo</or>
     <classtoc>Obsah tříd</classtoc>
+    <swrltoc>Obsah SWRL</swrltoc>     
     <objectpropertytoc>Obsah objektových vlastností</objectpropertytoc>
     <datapropertytoc>Obsah datových vlastností</datapropertytoc>
     <annotationpropertytoc>Obsah anotačních vlastností</annotationpropertytoc>

--- a/src/main/resources/lode/de.xml
+++ b/src/main/resources/lode/de.xml
@@ -70,6 +70,7 @@
     <developedby>erzeugt, entwickelt durch</developedby>
     <or>oder</or>
     <classtoc>Klassenübersicht</classtoc>
+    <swrltoc>Übersicht der SWRL</swrltoc>
     <objectpropertytoc>Übersicht der Objekteigenschaften</objectpropertytoc>
     <datapropertytoc>Übersicht der Dateneigenschaften</datapropertytoc>
     <annotationpropertytoc>Übersicht der Anmerkungseigenschaften</annotationpropertytoc>

--- a/src/main/resources/lode/en.xml
+++ b/src/main/resources/lode/en.xml
@@ -71,6 +71,7 @@
     <developedby>developed by</developedby>
     <or>or</or>
     <classtoc>Class ToC</classtoc>
+    <swrltoc>SWRL ToC</swrltoc>
     <objectpropertytoc>Object Property ToC</objectpropertytoc>
     <datapropertytoc>Data Property ToC</datapropertytoc>
     <annotationpropertytoc>Annotation Property ToC</annotationpropertytoc>

--- a/src/main/resources/lode/es.xml
+++ b/src/main/resources/lode/es.xml
@@ -70,6 +70,7 @@
     <developedby>desarrollado por</developedby>
     <or>o</or>
     <classtoc>Índice de clases</classtoc>
+    <swrltoc>Índice de SWRL</swrltoc>
     <objectpropertytoc>Índice de propiedades de objetos</objectpropertytoc>
     <datapropertytoc>Índice de propiedades de datos</datapropertytoc>
     <annotationpropertytoc>Índice de propiedades de anotación</annotationpropertytoc>

--- a/src/main/resources/lode/swrl-module.xsl
+++ b/src/main/resources/lode/swrl-module.xsl
@@ -69,7 +69,11 @@ Copyright (C) 2023, Victor Chavez <vchavezb@protonmail.com>
                         <xsl:value-of select="concat('Rule #', count(preceding-sibling::swrl:Imp | preceding-sibling::rdf:Description[rdf:type[@rdf:resource = 'http://www.w3.org/2003/11/swrl#Imp']]) + 1)"/>
                     </xsl:otherwise>
                 </xsl:choose>
-                <xsl:call-template name="get.backlink.to.top" />
+                <xsl:call-template name="get.backlink.to.top">
+                    <xsl:with-param name="toc" select="'swrlrules'" tunnel="yes" as="xs:string"/>
+                    <xsl:with-param name="toc.string" select="f:getDescriptionLabel('swrltoc')" tunnel="yes"
+                                    as="xs:string"/>
+                </xsl:call-template>
             </h3>
             <p>
                 <!-- Add rdfs:comment -->


### PR DESCRIPTION
The SWRL xslt extraction was missing function input parameters to set correctly the SWRL ToC which made only the "back to Toc" to appear.