### PR TITLE
Allow loading local ontologies for imports

### DIFF
--- a/src/main/java/widoco/Configuration.java
+++ b/src/main/java/widoco/Configuration.java
@@ -121,6 +121,7 @@ public class Configuration {
     private boolean includeAllSectionsInOneDocument; //boolean to indicate all sections should be included in a single big HTML
 	private HashMap<String, String> namespaceDeclarations; //Namespace declarations to be included in the documentation.
 	private String introText;// in case there is an explicit annotation in the ontology
+	private List<File> imports = new ArrayList<>();
 
 	/**
 	 * Variable to keep track of possible errors in the changelog. If there are
@@ -1050,6 +1051,12 @@ public class Configuration {
 		this.mainOntologyMetadata.setNamespaceURI(ontologyURI);
 	}
 
+	public void setImports(List<String> imports) {
+		for (String importStr:imports) {
+			this.imports.add(new File(importStr));
+		}
+	}
+
 	public void setPublishProvenance(boolean publishProvenance) {
 		this.publishProvenance = publishProvenance;
 	}
@@ -1072,6 +1079,10 @@ public class Configuration {
 
 	public String getReferencesPath() {
 		return referencesPath;
+	}
+
+	public List<File> getImports() {
+		return this.imports;
 	}
 
 	public boolean isIncludeAbstract() {

--- a/src/main/java/widoco/WidocoUtils.java
+++ b/src/main/java/widoco/WidocoUtils.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.FileUtils;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.io.FileDocumentSource;
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.util.AutoIRIMapper;
 
 /**
  * Some useful methods reused across different classes
@@ -69,6 +70,13 @@ public class WidocoUtils {
 		((CatalogIRIMapper) jenaCatalogMapper).printMap();
 		OWLOntologyLoaderConfiguration loadingConfig = new OWLOntologyLoaderConfiguration();
 		loadingConfig = loadingConfig.setMissingImportHandlingStrategy(MissingImportHandlingStrategy.SILENT);
+		if (c.getImports()!=null){
+			for(File importDir:c.getImports()){
+				AutoIRIMapper mapper = new AutoIRIMapper(importDir, true);
+				manager.getIRIMappers().add(mapper);
+			}
+		}
+
 		OWLOntology ontology = manager
 				.loadOntologyFromOntologyDocument(new FileDocumentSource(new File(c.getOntologyPath())), loadingConfig);
 		c.getMainOntology().setMainOntology(ontology);

--- a/src/main/java/widoco/gui/GuiController.java
+++ b/src/main/java/widoco/gui/GuiController.java
@@ -21,7 +21,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -101,11 +103,12 @@ public final class GuiController {
 
 		// get the arguments
 		String outFolder = "myDocumentation" + (new Date().getTime()), ontology = "", rb = null, configOutFile = null;
+		List<String> imports = new ArrayList<>();
 		boolean isFromFile = false, oops = false, rewriteAll = false, getOntoMetadata = true, useW3Cstyle = true,
 				includeImportedOntologies = false, htAccess = false, webVowl = false, errors = false, licensius = false,
 				generateOnlyCrossRef = false, includeNamedIndividuals = true, includeAnnotationProperties = false,
 				displaySerializations = true, displayDirectImportsOnly = false, excludeIntroduction = false, uniteSections = false,
-				placeHolderText = true;
+				placeHolderText = true, localImports=false;
 		String confPath = "";
 		String code = null;// for tracking analytics.
 		String[] languages = null;
@@ -129,6 +132,11 @@ public final class GuiController {
 				break;
 			case "-ontURI":
 				ontology = args[i + 1];
+				i++;
+				break;
+			case "-import":
+				imports.add(args[i + 1]);
+				localImports = true;
 				i++;
 				break;
 			case "-oops":
@@ -267,6 +275,9 @@ public final class GuiController {
 		}
 		if (!isFromFile)
 			this.config.setOntologyURI(ontology);
+		if(localImports) {
+			this.config.setImports(imports);
+		}
 
 		logger.info("Processed configuration, loading ontology now. isFromFile=" + (isFromFile ? "true" : "false"));
 


### PR DESCRIPTION
This change allows to use local imports with the AutoIRIMapper from the owl api.

## Motivation

I am working on a project that defines several ontologies. The pipeline generates the documentation for each of them in a single job and it imports online definitions. However, I have made local copies and this reduces the processing time from 5-6 minutes to 2 minutes.

## Use cases
- load imports locally for optimization of loading time instead of downloading.
- Use local ontologies that are in development instead of pulling the current online version. Example Ontology A imports ontology B. Ontology B is also part of the main git repo of the developer. If Ontology B has changes that ontology A needs and are not online then there will be missing definitions.

To enable this option use `-import` with a directory path. The option can be used multiple times in the same command line.

Feel free to add comments or feedback to improve this suggestion.