### PR TITLE
fix(extraction): Do not force lower-case if URI do not have label

### DIFF
--- a/src/main/resources/lode/extraction.xsl
+++ b/src/main/resources/lode/extraction.xsl
@@ -712,7 +712,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
                     <xsl:otherwise>
                         <xsl:variable name="camelCase" select="replace($localName,'([A-Z])',' $1')"/>
                         <xsl:variable name="underscoreOrDash" select="replace($camelCase,'(_|-)',' ')"/>
-                        <xsl:value-of select="normalize-space(lower-case($underscoreOrDash))"/>
+                        <xsl:value-of select="normalize-space($underscoreOrDash)"/>
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:otherwise>


### PR DESCRIPTION
In the case the URI do not have any label, a generic one is generated regarding the URI fragment. It was forced to lower case, which leads to a miscomprehension for class label. It is commonly accepted that classes label starts with a uppercase letter.

For example:
```turtle
:MyClass a owl:Class;
         owl:equivalentClass schema:Person.
```
leaded to a result in the doc like:
"MyClass is equivalent to person"
When we want :
"MyClass is equivalent to Person"