### PR TITLE
bugfixes

### DIFF
--- a/src/main/java/widoco/Constants.java
+++ b/src/main/java/widoco/Constants.java
@@ -421,7 +421,7 @@ public class Constants {
 "    -uniteSections: Write all HTML sections into a single HTML document. \n" +
 "    -noPlaceHolderText: Do not add any placeholder text (this will remove intro, abstract (if empty) and " +
 				"description sections)." +
-"    --help: Shows this message and exit.\n";  
+"    --help: Shows this message and exit.\n";
 
 	/**
 	 * Head section of the HTML document.
@@ -444,7 +444,7 @@ public class Constants {
 
 	/**
 	 * Text representing the div of the status.
-	 * 
+	 *
 	 * @param c
 	 * @return
 	 */
@@ -646,7 +646,7 @@ public class Constants {
 	 * Serialization of the JSON LD for the ontology specification. Given that I
 	 * have faced some serialization issues, I serialize it by hand, using basic
 	 * properties.
-	 * 
+	 *
 	 * @param c
 	 * @return
 	 */
@@ -903,7 +903,7 @@ public class Constants {
          * @param abs abstract section
          * @param intro introduction section
          * @param overview overview section
-         * @param des description section 
+         * @param des description section
          * @param references references section
          * @param changelog changelog section
          * @param crossRef cross reference section
@@ -935,7 +935,7 @@ public class Constants {
 		document += "<script src=\"" + resourcesFolderName + "/jquery.js\"></script> \n" + "<script src=\""
 				+ resourcesFolderName + "/marked.min.js\"></script> \n" + "    "
                         + "<script> \n" + "function loadHash() {\n"
-				+ "  jQuery(\".markdown\").each(function(el){jQuery(this).after(marked(jQuery(this).text())).remove()});\n"
+				+ "  jQuery(\".markdown\").each(function(el){jQuery(this).after(marked.parse(jQuery(this).text())).remove()});\n"
 				+ "	var hash = location.hash;\n" + "	if($(hash).offset()!=null){\n"
 				+ "	  $('html, body').animate({scrollTop: $(hash).offset().top}, 0);\n" + "}\n" + "	loadTOC();\n"
 				+ "}\n" + "function loadTOC(){\n" + "	//process toc dynamically\n" + "	  var t='<h2>"
@@ -947,8 +947,8 @@ public class Constants {
 				+ "				t+='<ul>';\n" + "			}\n" + "			j++;\n"
 				+ "			t+= '<li>'+(i-1)+'.'+j+'. '+'<a href=#'+ jQuery(this).attr('id')+'>'+ jQuery(this).ignore(\"span\").text()+'</a></li>';\n"
 				+ "		}\n" + "	  });\n" + "	  t+='</ul>';\n" + "	  $(\"#toc\").html(t); \n" + "}\n"
-                                + "$(function(){\n" 
-                                + "    loadHash();\n" 
+                                + "$(function(){\n"
+                                + "    loadHash();\n"
                                 + "});"
 				+ " $.fn.ignore = function(sel){\n" + "        return this.clone().find(sel||\">*\").remove().end();\n"
 				+ " };" + " \n";
@@ -1220,7 +1220,7 @@ public class Constants {
 			provURI = "..\\index-" + c.getCurrentLanguage() + ".html";
 		}
 		String provrdf = "@prefix prov: <http://www.w3.org/ns/prov#> .\n"
-				+ "@prefix dc: <http://purl.org/dc/terms/> .\n" 
+				+ "@prefix dc: <http://purl.org/dc/terms/> .\n"
                                 + "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n"
                                 + "@prefix : <> .\n";
 		provrdf += "<" + provURI + "> a prov:Entity;\n";
@@ -1323,8 +1323,8 @@ public class Constants {
 				+ "<dt><span class=\"label label-minor\">Minor</span></dt> <dd>It is not really a problem, but by correcting it we will make the ontology nicer.</dd>\n"
 				+ "</dl>" + evaluationContent +
 				// references
-				"<p>References:</p>\n" + 
-				"    <ul>\n" + 
+				"<p>References:</p>\n" +
+				"    <ul>\n" +
                 "<li>\n"+
 				"    [1] Aguado-De Cea, G., Montiel-Ponsoda, E., Poveda-Villalón, M., and Giraldo-Pasmin, O.X. (2015). Lexicalizing Ontologies: The issues behind the labels. In Multimodal communication in the 21st century: Professional and academic challenges. 33rd Conference of the Spanish Association of Applied Linguistics (AESLA), XXXIII AESLA." +
                 "</li>\n"+
@@ -1380,7 +1380,7 @@ public class Constants {
 	/**
 	 * Method that writes an htaccess file according to the W3C best practices. Note
 	 * that hash is different from slash
-	 * 
+	 *
 	 * @param c Configuration parameter with the language parameters
 	 * @return a String with the htaccess file
 	 */
@@ -1497,7 +1497,7 @@ public class Constants {
 
 	/**
 	 * Text for the 406 page
-	 * 
+	 *
 	 * @param c
 	 * @param lang
 	 * @return the content of the 406 page

--- a/src/main/java/widoco/gui/GuiController.java
+++ b/src/main/java/widoco/gui/GuiController.java
@@ -65,7 +65,7 @@ public final class GuiController {
 		System.out.println("\nYou are launching WIDOCO GUI\n");
 		System.out.println("\nTo use WIDOCO through the command line please type:\n");
 		System.out.println(Constants.HELP_TEXT);
-                
+
                 // read logo
 		try {
 			gui = new GuiStep1(this);
@@ -78,7 +78,7 @@ public final class GuiController {
 
 	/**
 	 * Method for running the application via console.
-	 * 
+	 *
 	 * @param args
 	 */
 	public GuiController(String[] args) {
@@ -256,10 +256,19 @@ public final class GuiController {
 			this.config.setIncludeIntroduction(false);
 		}
 		if (!placeHolderText){
-			this.config.setIncludeIntroduction(false);
-			this.config.setIncludeDescription(false);
-			this.config.setIncludeReferences(false);
-			this.config.setIncludeAbstract(false);
+      // only disable those not explicitly set
+      if( this.config.getIntroductionPath() == null ) {
+        this.config.setIncludeIntroduction(false);
+      }
+      if( this.config.getDescriptionPath() == null ) {
+        this.config.setIncludeDescription(false);
+      }
+      if( this.config.getReferencesPath() == null ) {
+        this.config.setIncludeReferences(false);
+      }
+      if( this.config.getAbstractPath() == null ) {
+        this.config.setIncludeAbstract(false);
+      }
 		}
 		if (code != null) {
 			this.config.setGoogleAnalyticsCode(code);

--- a/src/main/resources/lode/extraction.xsl
+++ b/src/main/resources/lode/extraction.xsl
@@ -137,7 +137,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
         <script>
             $(document).ready(
             function () {
-            jQuery(".markdown").each(function(el){jQuery(this).after(marked(jQuery(this).text())).remove()});
+            jQuery(".markdown").each(function(el){jQuery(this).after(marked.parse(jQuery(this).text())).remove()});
             var list = $('a[name="<xsl:value-of select="$ontology-url"/>"]');
             if (list.size() != 0) {
             var element = list.first();
@@ -574,7 +574,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
         <xsl:variable name="label" select="f:getLabel(.)" as="xs:string"/>
         <xsl:choose>
             <xsl:when test="$anchor = ''">
-                <!-- Change to make the external links open in a new window 
+                <!-- Change to make the external links open in a new window
                 instead of being dotted
                 <span class="dotted" title="{.}">
                     <xsl:value-of select="$label" />
@@ -631,7 +631,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
 
     <!-- <xsl:function name="f:getLabel" as="xs:string">
         <xsl:param name="iri" as="xs:string" />
-        
+
         <xsl:variable name="node" select="$root//rdf:RDF/element()[(@*:about = $iri or @*:ID = $iri) and exists(rdfs:label)][1]" as="element()*" />
         <xsl:choose>
             <xsl:when test="exists($node/rdfs:label)">
@@ -688,7 +688,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
                     <xsl:variable
                             name="current-index"
                             select="if (contains($iri,'#'))
-                                    then f:string-first-index-of($iri,'#') 
+                                    then f:string-first-index-of($iri,'#')
                                     else f:string-last-index-of(replace($iri,'://','---'),'/')"
                             as="xs:integer?"/>
                     <xsl:if test="exists($current-index) and string-length($iri) != $current-index">
@@ -2016,7 +2016,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
 
     <!--
         input: un elemento tipicamente contenente solo testo
-        output: un booleano che risponde se quell'elemento è quello giusto per la lingua considerata        
+        output: un booleano che risponde se quell'elemento è quello giusto per la lingua considerata
     -->
     <xsl:function name="f:isInLanguage" as="xs:boolean">
         <xsl:param name="el" as="element()"/>
@@ -2024,7 +2024,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
         <xsl:variable name="isDefLang" select="$el/@xml:lang = $def-lang" as="xs:boolean"/>
 
         <xsl:choose>
-            <!-- 
+            <!--
                 Ritorno false se:
                 - c'è qualche elemento prima di me del linguaggio giusto OR
                 - io non sono del linguaggio giusto AND

--- a/src/main/resources/lode/owl.css
+++ b/src/main/resources/lode/owl.css
@@ -8,7 +8,7 @@
     font-size: 95%;
 }
 #abstract br {
-   /* doesn't work right SOMETIMES 
+   /* doesn't work right SOMETIMES
    margin-bottom: 1em;   */
 }
 .name {
@@ -21,7 +21,7 @@
     padding-right: 1ex;
     padding-top: 1ex;
     padding-bottom: 0.6ex;
-    border: 1px dotted black; 
+    border: 1px dotted black;
 }
 .grammar {
     margin-top: 1ex;
@@ -59,7 +59,7 @@
     background-color: #FFA;
 }
 .atrisknotehead {
-    font-style: italic;	
+    font-style: italic;
 }
 
 /* Stying the examples. */
@@ -87,15 +87,15 @@
 /* Styling the parts in the functional-style syntax. */
 
 div.fss {
-    margin-top: 10px; 
-    margin-bottom: 10px; 
-    margin-left: 20px; 
-    margin-right: 20px; 
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 20px;
+    margin-right: 20px;
     font-family: monospace;
 }
 table.fss {
-    margin: 0px 0px 0px 0px; 
-    padding: 0px 0px 0px 0px; 
+    margin: 0px 0px 0px 0px;
+    padding: 0px 0px 0px 0px;
     width: 100%;
 }
 table.fss caption.fss {
@@ -111,8 +111,8 @@ table.fss td:first-child {
     width: 60%;
 }
 table{
-    background-color: #f4ffff;
-    border: 1px solid navy;
+    background-color: var(--bg-hlist);
+    border: 1px solid var(--border);
     margin: 20px;
     vertical-align: middle;
 }
@@ -124,15 +124,15 @@ table td {
 /* Styling the parts in the RDF syntax. */
 
 div.rdf{
-    margin-top: 10px; 
-    margin-bottom: 10px; 
-    margin-left: 20px; 
-    margin-right: 20px; 
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 20px;
+    margin-right: 20px;
     font-family: monospace;
 }
 table.rdf {
-    margin: 0px 0px 0px 0px; 
-    padding: 0px 0px 0px 0px; 
+    margin: 0px 0px 0px 0px;
+    padding: 0px 0px 0px 0px;
     width: 100%;
 }
 table.rdf caption.rdf {
@@ -151,17 +151,17 @@ table.rdf td:first-child {
 /* Styling the XML syntax. */
 
 div.xmlsyn {
-    margin-top: 10px; 
-    margin-bottom: 10px; 
-    margin-left: 20px; 
-    margin-right: 20px; 
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 20px;
+    margin-right: 20px;
     font-family: monospace;
 }
 div.axioms {
-    margin-top: 10px; 
-    margin-bottom: 10px; 
-    margin-left: 20px; 
-    margin-right: 20px; 
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 20px;
+    margin-right: 20px;
 }
 
 /* Other styles. */
@@ -225,7 +225,7 @@ div {
     margin-bottom: 0;
 }
 #fulltitle {
-  font-size: 140%; 
+  font-size: 140%;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Hi,

I fiddled around with Widoco today and caught a few issues I consider bugs. The three commits each target one of the following:

1. Dark Mode: namespace table still used light mode styling
    * I added the CSS variables in the respective CSS file also for the `table` style
2. `-noPlaceHolderText` overrides manually set paths to abtract etc
   * It could be argued that this is intended behavior but I'd consider this a bug. As a user I only want to prohibit placeholders and not the texts I explicitly set.
   * I changed the behavior so that the config file's `pathToAbstract` etc supersede `-noPlaceHolderText`. Now, only the text that are not set are hidden.
3. When using `-uniteSections`, some `marked` JavaScript failed.
   * I assume this was just missed when updating `marked` at some point. It was already fixed in one place but left open in two other places.

If need be, I can also make this 3 separate pull requests but for me it was easier to include all my fixes into one.

cheers,
Sirko

PS: it would be really nice if these were included in a bugfix release, so I can use it directly in my CI/CD pipelines.
PPS: I'm sorry for the extensive whitespace changes. My editor is just configured to trim upon save.