### PR TITLE
Automatic build and push of docker image to dockerhub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   push_to_registry:
-    name: Release docker image and jar files
+    name: Release docker image
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,36 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Release docker image and jar files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ vars.DOCKER_REPO }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .  
+          file: ./Dockerfile
+          push: true
+          build-args: GITHUB_REF=${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This merge request completes the feature request [#696](https://github.com/dgarijo/Widoco/issues/696)

In order for the new workflow to work. Several additional actions need to be taken:

On dockerhub
1) Go to https://hub.docker.com/ and create an account if you don't already have one
2) Create a private token with read/write privileges
3) Create a public repository named 'Widoco' and fill out the metadata (point towards this github repository)

On github
1) Go to the settings of the Widoco repository
2) Under Secrets and variables / Actions create 2 new secrets named 

![image](https://github.com/dgarijo/Widoco/assets/15101339/5850a199-bd17-48f9-9e4b-7592f42643bf)

3) Under  'variables' tab, create the new variable `DOCKER_REPO `with your username followed by the dockerhub repository name. In my case: `vbp8501mvda/widoco`

![image](https://github.com/dgarijo/Widoco/assets/15101339/a63ca6b6-4c3d-4ac8-bae1-1f4189b406d8)

4) Create a new release to test the configuration and deploy the first docker image on dockerhub
5) Celebrate! 