### PR TITLE
CLI option to exclude provenance link

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ docker run -ti --rm \
 
 `-noPlaceHolderText`: Do not add any placeholder text (this will remove intro, abstract (if empty) and description sections).
 
+`-excludeProvenance`: Do not add the link "Provenance of this page" in the metadata header section
+
 `-ontFile PATH`  [required (unless -ontURI is used)]: Load a local ontology file (from PATH) to document. This option is incompatible with -ontURI
 
 `-outFolder folderName`: Specifies the name of the folder where to save the documentation. By default is 'myDocumentation'

--- a/src/main/java/widoco/gui/GuiController.java
+++ b/src/main/java/widoco/gui/GuiController.java
@@ -107,8 +107,8 @@ public final class GuiController {
 		boolean isFromFile = false, oops = false, rewriteAll = false, getOntoMetadata = true, useW3Cstyle = true,
 				includeImportedOntologies = false, htAccess = false, webVowl = false, errors = false, licensius = false,
 				generateOnlyCrossRef = false, includeNamedIndividuals = true, includeAnnotationProperties = false,
-				displaySerializations = true, displayDirectImportsOnly = false, excludeIntroduction = false, uniteSections = false,
-				placeHolderText = true, localImports=false;
+				displaySerializations = true, displayDirectImportsOnly = false, excludeIntroduction = false, excludeProvenance = false,
+			    uniteSections = false, placeHolderText = true, localImports=false;
 		String confPath = "";
 		String code = null;// for tracking analytics.
 		String[] languages = null;
@@ -203,6 +203,9 @@ public final class GuiController {
 			case "-noPlaceHolderText":
 				placeHolderText = false;
 				break;
+			case "-excludeProvenance":
+				excludeProvenance = true;
+				break;
 			case "--help":
 				System.out.println(Constants.HELP_TEXT);
 				return;
@@ -269,6 +272,9 @@ public final class GuiController {
       if( this.config.getAbstractPath() == null ) {
         this.config.setIncludeAbstract(false);
       }
+		}
+		if (excludeProvenance) {
+			this.config.setPublishProvenance(false);
 		}
 		if (code != null) {
 			this.config.setGoogleAnalyticsCode(code);


### PR DESCRIPTION
Hi,

For a project where we would like to achieve results similar to how [the ERA vocabulary](https://data-interop.era.europa.eu/era-vocabulary/) is published, we were missing an option to disable the generation of the link to provenance data. I can only assume that the authors of mentioned vocabulary manually commented out unwanted content in the Widoco-generated html.
To achieve a similar result in an automated manner, we exposed the `excludeProvenance`-option (that is available in the GUI?) in the CLI.