### PR TITLE
Add support for skos:scopeNote

### DIFF
--- a/doc/metadataGuide/guide.md
+++ b/doc/metadataGuide/guide.md
@@ -92,16 +92,17 @@ We prioritize reusing metadata properties defined already. However, a small subs
 
 The table below summarizes all the metadata annotations recognized for ontology terms, in alphabetical order. Note that there are no `config.properties` annotations here, as these annotations are only read from the ontology file.
 
-|Metadata category |Ontology annotation property                     |Good practices document    |Accepted property value|Example          |
-|------------------|-------------------------------------------------|---------------------------|-----------------------|-----------------|
-|Definition        |[rdfs:comment], [skos:definition]                |[Sec 4.2] **[RECOMMENDED]**|[Text]                 |[ontology](#term)|
-|Deprecation status|[owl:deprecated]                                 |[Sec 4.5.1] **[OPTIONAL]** |[Boolean]              |[ontology](#term)|
-|Editorial note    |[skos:editorialNote]                             |N/A **[OPTIONAL]**         |[Text]                 |[ontology](#term)|
-|Example           |[vann:example], [skos:example]                   |[Sec 4.4] **[OPTIONAL]**   |[Text]                 |[ontology](#term)|
-|Label             |[rdfs:label], [skos:prefLabel], [obo:IAO_0000118]|[Sec 4.1] **[RECOMMENDED]**|[Text]                 |[ontology](#term)|
-|Original source   |[rdfs:isDefinedBy], [dc:source]                  |[Sec 4.3] **[OPTIONAL]**   |[URI]                  |[ontology](#term)|
-|Rationale         |[vaem:rationale]                                 |[Sec 4.6] **[OPTIONAL]**   |[Text]                 |[ontology](#term)|
-|Status            |[sw:term_status], [obo:IAO_0000114]              |[Sec 4.5.2] **[OPTIONAL]** |[Text]                 |[ontology](#term)|
+| Metadata category  | Ontology annotation property                      |Good practices document    |Accepted property value|Example          |
+|--------------------|---------------------------------------------------|---------------------------|-----------------------|-----------------|
+| Definition         | [rdfs:comment], [skos:definition]                 |[Sec 4.2] **[RECOMMENDED]**|[Text]                 |[ontology](#term)|
+| Deprecation status | [owl:deprecated]                                  |[Sec 4.5.1] **[OPTIONAL]** |[Boolean]              |[ontology](#term)|
+| Editorial note     | [skos:editorialNote]                              |N/A **[OPTIONAL]**         |[Text]                 |[ontology](#term)|
+| Example            | [vann:example], [skos:example]                    |[Sec 4.4] **[OPTIONAL]**   |[Text]                 |[ontology](#term)|
+| Label              | [rdfs:label], [skos:prefLabel], [obo:IAO_0000118] |[Sec 4.1] **[RECOMMENDED]**|[Text]                 |[ontology](#term)|
+| Original source    | [rdfs:isDefinedBy], [dc:source]                   |[Sec 4.3] **[OPTIONAL]**   |[URI]                  |[ontology](#term)|
+| Rationale          | [vaem:rationale]                                  |[Sec 4.6] **[OPTIONAL]**   |[Text]                 |[ontology](#term)|
+| Scope note         | [skos:scopeNote]                                  |N/A **[OPTIONAL]**         |[Text]                 |[ontology](#term)|
+| Status             | [sw:term_status], [obo:IAO_0000114]               |[Sec 4.5.2] **[OPTIONAL]** |[Text]                 |[ontology](#term)|
 
 
 ## <span id="onto">Example: Using ontology annotations (<a href="#table">Back to table</a>)
@@ -206,6 +207,7 @@ For status, the known values are: `unstable`, `testing`, `stable` and `archaic`
             sw:status "unstable";
             rdfs:isDefinedBy <https://w3id.org/example#> ;
             skos:editorialNote "Some editorial note by the creator of the term" ;
+            skos:scopeNote "A note that helps to clarify the meaning and/or the use of a concept" ;
             rdfs:label "Researcher"@en .
 ```
 
@@ -428,6 +430,7 @@ TurtleSerialization=ontology.ttl
 [skos:example]:                  http://www.w3.org/2004/02/skos/core#example
 [skos:note]:                     http://www.w3.org/2004/02/skos/core#note
 [skos:prefLabel]:                http://www.w3.org/2004/02/skos/core#prefLabel
+[skos:scopeNote]:                http://www.w3.org/2004/02/skos/core#scopeNote
 [sw:term_status]:                http://www.w3.org/2003/06/sw-vocab-status/ns#
 [vaem:rationale]:                http://www.linkedmodel.org/schema/vaem#rationale
 [vann:example]:                  http://purl.org/vocab/vann/example

--- a/src/main/resources/lode/cs.xml
+++ b/src/main/resources/lode/cs.xml
@@ -88,5 +88,6 @@
     <rangeIncludes>range includes</rangeIncludes>
     <usesRule>uses rule</usesRule>
     <editorialNote>redakční poznámka</editorialNote>
+    <scopeNote>poznámka k rozsahu</scopeNote>
     <externalproperty>externí vlastnosti</externalproperty>
 </labels>

--- a/src/main/resources/lode/de.xml
+++ b/src/main/resources/lode/de.xml
@@ -89,5 +89,6 @@
     <scenarios>Szenarien</scenarios>
     <usesRule>verwendet die Regel</usesRule>
     <editorialNote>redaktionelle Anmerkung</editorialNote>
+    <scopeNote>umfang Anmerkung</scopeNote>
     <externalproperty>externe Eigenschaft</externalproperty>
 </labels>

--- a/src/main/resources/lode/en.xml
+++ b/src/main/resources/lode/en.xml
@@ -88,6 +88,7 @@
     <domainIncludes>domain includes</domainIncludes>
     <rangeIncludes>range includes</rangeIncludes>
     <editorialNote>editorial note</editorialNote>
+    <scopeNote>scope note</scopeNote>
     <usedByRuleInAntecedent>used by rule (in antecedent)</usedByRuleInAntecedent>
     <usedByRuleInConsequent>used by rule (in consequent)</usedByRuleInConsequent>
     <externalproperty>external property</externalproperty>

--- a/src/main/resources/lode/es.xml
+++ b/src/main/resources/lode/es.xml
@@ -88,5 +88,6 @@
     <rangeIncludes>el rango incluye</rangeIncludes>
     <usesRule>utiliza regla</usesRule>
     <editorialNote>nota editorial</editorialNote>
+    <scopeNote>nota de alcance</scopeNote>
     <externalproperty>propiedad externa</externalproperty>
 </labels>

--- a/src/main/resources/lode/extraction.xsl
+++ b/src/main/resources/lode/extraction.xsl
@@ -1025,6 +1025,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
 
     <xsl:template name="get.entity.metadata">
         <xsl:call-template name="get.skos.editorial.note"/>
+        <xsl:call-template name="get.skos.scope.note"/>
         <xsl:call-template name="get.version"/>
         <xsl:call-template name="get.author"/>
         <xsl:call-template name="get.original.source"/>
@@ -2262,6 +2263,21 @@ http://www.oxygenxml.com/ns/doc/xsl ">
                     <xsl:value-of select="f:getDescriptionLabel('editorialNote')"/>
                 </dt>
                 <xsl:for-each select="skos:editorialNote">
+                    <dd>
+                        <xsl:value-of select="text()"/>
+                    </dd>
+                </xsl:for-each>
+            </dl>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="get.skos.scope.note">
+        <xsl:if test="exists(skos:scopeNote)">
+            <dl>
+                <dt>
+                    <xsl:value-of select="f:getDescriptionLabel('scopeNote')"/>
+                </dt>
+                <xsl:for-each select="skos:scopeNote">
                     <dd>
                         <xsl:value-of select="text()"/>
                     </dd>

--- a/src/main/resources/lode/fr.xml
+++ b/src/main/resources/lode/fr.xml
@@ -88,4 +88,5 @@
     <rangeIncludes>cible comprend</rangeIncludes>
     <usesRule>utilise la règle</usesRule>
     <editorialNote>note éditoriale</editorialNote>
+    <scopeNote>note de portée</scopeNote>
 </labels>

--- a/src/main/resources/lode/it.xml
+++ b/src/main/resources/lode/it.xml
@@ -87,4 +87,5 @@
     <rangeIncludes>codominio include</rangeIncludes>
     <usesRule>usa la regola</usesRule>
     <editorialNote>nota redazionale</editorialNote>
+    <scopeNote>nota di scopo</scopeNote>
 </labels>

--- a/src/main/resources/lode/nl.xml
+++ b/src/main/resources/lode/nl.xml
@@ -87,4 +87,5 @@
     <rangeIncludes>bereik bevat</rangeIncludes>
     <usesRule>gebruikt regel</usesRule>
     <editorialNote>redactionele opmerking</editorialNote>
+    <scopeNote>scoop opmerking</scopeNote>
 </labels>

--- a/test/example_test.owl
+++ b/test/example_test.owl
@@ -108,6 +108,7 @@ xsd:date rdf:type rdfs:Datatype .
            rdfs:range :Researcher ;
            rdfs:comment "This example property indicates that an Organization has a Researcher as member"@en ;
            skos:editorialNote "banana in pajama"@en ;
+           skos:scopeNote "Use obj prop only for researchers in the specified organisation"@en ;
            rdfs:label "has member"@en .
 
 
@@ -144,6 +145,7 @@ xsd:date rdf:type rdfs:Datatype .
            rdfs:domain :Organization ;
            rdfs:range xsd:date ;
            skos:editorialNote "banana in pajama data prop"@en ;
+           skos:scopeNote "Use data prop only for researchers in the specified organisation"@en ;
            rdfs:comment "Date when an organization was founded"@en ;
            rdfs:label "founded in"@en .
 
@@ -163,6 +165,7 @@ xsd:date rdf:type rdfs:Datatype .
               <http://purl.org/vocab/vann/example> "University of Southern California"@en ;
               rdfs:comment "An organized body of people with a particular purpose, especially a business, society, association, etc."@en ;
               skos:editorialNote "SKOS note"@en ;
+              skos:scopeNote "Use this class for organisations"@en ;
               owl:equivalentClass <http://xmlns.com/foaf/0.1/Organization>;
               skos:prefLabel "organization";
               rdfs:isDefinedBy <https://w3id.org/example> ;


### PR DESCRIPTION
According to the discussion in this [issue](https://github.com/w3c/dxwg/issues/233), we use `skos:scopeNote` in our ontology to clarify the expected usage of certain classes and properties. To prepare this PR, I followed the PR for adding support to `skos:editorialNote` (https://github.com/dgarijo/Widoco/pull/616). Labels are translated automatically.