### PR TITLE
Disable DTD parsing to avoid XXEs

### DIFF
--- a/src/main/java/widoco/LODEParser.java
+++ b/src/main/java/widoco/LODEParser.java
@@ -182,6 +182,7 @@ public class LODEParser {
 
 		try {
 			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document doc = db.parse(new ByteArrayInputStream(content.getBytes("UTF-8")));// StandardCharsets.UTF_8
 


### PR DESCRIPTION
This PR contains the same changes as  #752  but now targeting the develop branch as requested.

## Description

Fixes a potential XXE vulnerabilities in the codebase. 

The risk of exploiting these vulnerabilities is considered very low, as some of the content originates from configuration settings. However, following the principle of least privilege, it is advisable to disable DTD if it does not impact functionality.


The patch is directly based on the OWASP cheat sheet.
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html

Instructions for Reviewers
Determine if there are any XML files that require support for external entity parsing.