### PR TITLE
Fix/iss 779 inc altlabel

### DIFF
--- a/src/main/resources/lode/cs.xml
+++ b/src/main/resources/lode/cs.xml
@@ -88,6 +88,7 @@
     <rangeIncludes>range includes</rangeIncludes>
     <usesRule>uses rule</usesRule>
     <editorialNote>redakční poznámka</editorialNote>
+    <altLabel>Alternativní označení</altLabel>
     <scopeNote>poznámka k rozsahu</scopeNote>
     <externalproperty>externí vlastnosti</externalproperty>
 </labels>

--- a/src/main/resources/lode/de.xml
+++ b/src/main/resources/lode/de.xml
@@ -89,6 +89,7 @@
     <scenarios>Szenarien</scenarios>
     <usesRule>verwendet die Regel</usesRule>
     <editorialNote>redaktionelle Anmerkung</editorialNote>
+    <altLabel>alternatives Label</altLabel>
     <scopeNote>umfang Anmerkung</scopeNote>
     <externalproperty>externe Eigenschaft</externalproperty>
 </labels>

--- a/src/main/resources/lode/en.xml
+++ b/src/main/resources/lode/en.xml
@@ -88,6 +88,7 @@
     <domainIncludes>domain includes</domainIncludes>
     <rangeIncludes>range includes</rangeIncludes>
     <editorialNote>editorial note</editorialNote>
+    <altLabel>Alternative label</altLabel>
     <scopeNote>scope note</scopeNote>
     <usedByRuleInAntecedent>used by rule (in antecedent)</usedByRuleInAntecedent>
     <usedByRuleInConsequent>used by rule (in consequent)</usedByRuleInConsequent>

--- a/src/main/resources/lode/es.xml
+++ b/src/main/resources/lode/es.xml
@@ -88,6 +88,7 @@
     <rangeIncludes>el rango incluye</rangeIncludes>
     <usesRule>utiliza regla</usesRule>
     <editorialNote>nota editorial</editorialNote>
+    <altLabel>etiqueta alternativa</altLabel>
     <scopeNote>nota de alcance</scopeNote>
     <externalproperty>propiedad externa</externalproperty>
 </labels>

--- a/src/main/resources/lode/extraction.xsl
+++ b/src/main/resources/lode/extraction.xsl
@@ -1024,6 +1024,7 @@ http://www.oxygenxml.com/ns/doc/xsl ">
     </xsl:template>
 
     <xsl:template name="get.entity.metadata">
+        <xsl:call-template name="get.skos.alt.label"/>
         <xsl:call-template name="get.skos.editorial.note"/>
         <xsl:call-template name="get.skos.scope.note"/>
         <xsl:call-template name="get.version"/>
@@ -1034,6 +1035,21 @@ http://www.oxygenxml.com/ns/doc/xsl ">
         <xsl:call-template name="get.deprecated"/>
         <xsl:call-template name="get.rule.antecedent"/>
         <xsl:call-template name="get.rule.consequent"/>
+    </xsl:template>
+
+    <xsl:template name="get.skos.alt.label">
+        <xsl:if test="exists(skos:altLabel)">
+            <dl>
+                <dt>
+                    <xsl:value-of select="f:getDescriptionLabel('altLabel')"/>
+                </dt>
+                <xsl:for-each select="skos:altLabel">
+                    <dd>
+                        <xsl:value-of select="text()"/>
+                    </dd>
+                </xsl:for-each>
+            </dl>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="get.original.source">

--- a/src/main/resources/lode/fr.xml
+++ b/src/main/resources/lode/fr.xml
@@ -88,5 +88,6 @@
     <rangeIncludes>cible comprend</rangeIncludes>
     <usesRule>utilise la règle</usesRule>
     <editorialNote>note éditoriale</editorialNote>
+    <altLabel>label alternatif</altLabel>
     <scopeNote>note de portée</scopeNote>
 </labels>

--- a/src/main/resources/lode/it.xml
+++ b/src/main/resources/lode/it.xml
@@ -87,5 +87,6 @@
     <rangeIncludes>codominio include</rangeIncludes>
     <usesRule>usa la regola</usesRule>
     <editorialNote>nota redazionale</editorialNote>
+    <altLabel>etichetta alternativa</altLabel>
     <scopeNote>nota di scopo</scopeNote>
 </labels>

--- a/src/main/resources/lode/nl.xml
+++ b/src/main/resources/lode/nl.xml
@@ -87,5 +87,6 @@
     <rangeIncludes>bereik bevat</rangeIncludes>
     <usesRule>gebruikt regel</usesRule>
     <editorialNote>redactionele opmerking</editorialNote>
+    <altLabel>alternatief label</altLabel>
     <scopeNote>scoop opmerking</scopeNote>
 </labels>

--- a/src/main/resources/lode/pt.xml
+++ b/src/main/resources/lode/pt.xml
@@ -81,4 +81,5 @@
 	<category>Categoria</category>
 	<isrequired>É necessário</isrequired>
 	<source>Fonte</source>
+    <altLabel>rótulo alternativo</altLabel>
 </labels>


### PR DESCRIPTION
include SKOS alternative labels in documentation

Motivation:

From the SKOS primer:
> The skos:altLabel property makes it possible to assign an alternative
> lexical label to a concept. This is especially helpful when assigning
> labels beyond the one that is preferred for the concept, for instance
> when synonyms need to be represented:

Such properties are currently not included in the Widoco output.  The
absence of altLabel in the documentation creates a barrier to people who
are most familiar with the concept in terms of a synonym: a person might
be unsure if the term is the desired one if the synonym isn't listed, or
might search (on the webpage) for a term using the synonym, etc.

Modification:

The XSLT is updated to generate a new section in the metadata part of an
entity's description.  This new section is only present if the entity
has at least one `skos:altLabel` assertion, otherwise no additional
output is generated.  If the entity has at least one `skos:altLabel`
assertion then a section header is included followed by a list of the
`skos:altLabel` assertion values, using HTML's description list
(`dl`/`dt`/`dd`).

This new section is labelled `Alternative label` in English locale
output.  Auto-translated equivalent terms has been added for the other
supported languages.

Result:

The generated webpage(s) now include information from `skos:altLabel`
assertions.

Closes: #779