### PR TITLE
Add maven-compiler-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.1</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>


### PR DESCRIPTION
Maven complains about compromised reproducability of builds if the maven-compiler-plugin version is not specified.