### PR TITLE
Identify non-release builds as SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>es.oeg</groupId>
 	<artifactId>widoco</artifactId>
 	<packaging>jar</packaging>
-	<version>1.4.26</version>
+	<version>1.4.26-SNAPSHOT</version>
 	<name>Widoco</name>
 
 	<properties>


### PR DESCRIPTION
Motivation:

Current builds contain a complete version, which could lead to confusion.

Modification:

Adopt maven's SNAPSHOT support.  This is a feature where builds that are not from a release are given a SNAPSHOT label by appending `-SNAPSHOT` to the version string.  The maven `release` plugin handles updating the version and tagging of releases.

Result:

Less confusion over intermediate builds.