### PR TITLE
Go to latest maintained java version in Docker and adjust some folder access rights for use in devcontainers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ----
-FROM maven:3.8.3-openjdk-17-slim AS build_image
+FROM maven:3.9.12-eclipse-temurin-11-alpine AS build_image
 
 WORKDIR /var/build/widoco
 
@@ -9,7 +9,7 @@ RUN mvn package && \
     mv ./JAR/widoco*.jar ./JAR/widoco.jar
 
 # ----
-FROM openjdk:17-slim
+FROM eclipse-temurin:11-jdk-noble
 
 RUN apt-get update
 RUN apt-get install -y libfreetype6 fontconfig
@@ -17,6 +17,9 @@ RUN apt-get install -y libfreetype6 fontconfig
 RUN useradd widoco
 RUN mkdir -p /usr/local/widoco
 RUN chown -R widoco:widoco /usr/local/widoco
+
+# allow execution of widoco with another UID while using the container's GID for writing the tmp files
+RUN chmod -R 0775 /usr/local/widoco
 
 USER widoco
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN mkdir -p /usr/local/widoco
 RUN chown -R widoco:widoco /usr/local/widoco
 
 # allow execution of widoco with another UID while using the container's GID for writing the tmp files
-RUN chmod -R 0775 /usr/local/widoco
+# UPDATE: all users need to have write permissions to the widoco folder, otherwise issues with .devcontainers
+RUN chmod -R 0777 /usr/local/widoco
 
 USER widoco
 


### PR DESCRIPTION
Docker Hub does not provide openjdk:17-slim anymore.