### PR TITLE
[Fix] Remove ontology namespace URI from HTML node ID after decoding URL

### DIFF
--- a/src/main/java/widoco/LODEParser.java
+++ b/src/main/java/widoco/LODEParser.java
@@ -349,7 +349,6 @@ public class LODEParser {
 					Node firstAnchor = currentNode.getFirstChild();
 					Node secondAnchor = firstAnchor.getNextSibling();
 					String newID = firstAnchor.getAttributes().getNamedItem("name").getNodeValue();
-					newID = newID.replace(c.getMainOntology().getNamespaceURI(), "");
 
 					try {
 						// if the URI contains special characters, we must decode them for referencing
@@ -358,6 +357,10 @@ public class LODEParser {
 					} catch (Exception e) {
 						logger.error("Error when encoding node.");
 					}
+
+					// remove ontology namespace
+					newID = newID.replace(c.getMainOntology().getNamespaceURI(), "");
+
 					if (newID.startsWith("#")) {
 						newID = newID.replace("#", "");
 					} // fix in case the author insert the NS URI without "#"


### PR DESCRIPTION
The current implementation of `LODEParser` first attempts to remove the ontology namespace from the node identifier, then decodes it and processes it further.

That expects the ontology namespace URI to be a URL-encoded identifier, which I believe is a bug.

This PR moves the namespace removal after the ID is decoded.

Example:
Consider the following ontology:
```ttl
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix vann: <http://purl.org/vocab/vann/> .
# intentionally using non ASCII characters
@prefix example: <http://example.com/spéciál/ontology/> .

<http://example.com/spéciál/ontology/> a owl:Ontology ;
    rdfs:label "Example ontology"@en;
    vann:preferredNamespaceUri <http://example.com/spéciál/ontology/> ;
    vann:preferredNamespacePrefix "example".


example:Class a owl:Class;
    rdfs:label "Example class"@en .
```

Before this fix, the generated HTML looks like
```html
<div class="entity" id="http://example.com/spéciál/ontology/Class">
```

With this fix applied:
```html
<div class="entity" id="Class">
```

Running widoco with: `java -jar widoco-1.4.26-jar-with-dependencies.jar -ontFile example-ontology.ttl -uniteSections`